### PR TITLE
feat: Pull api creds and base urls into config

### DIFF
--- a/lib/atajo.io.js
+++ b/lib/atajo.io.js
@@ -38,6 +38,11 @@ _io = {
         _.CONFIG = require('../../conf/config.json');
         _.KEYS = require('../../conf/keys.json');
 
+        try{
+            _.CONFIG.API_AUTH = require('../../conf/api_auth.json');
+        } catch(e) {
+            atajo.log.e("COULD NOT FIND conf/api_auth.json");
+        }
 
         _.CONFIG.API_KEY = _.KEYS.API_KEY;
         _.CONFIG.CLIENT_KEY = _.KEYS.CLIENT_KEY;


### PR DESCRIPTION
*Issue:*
- Every time we update the config locally, we need to checkout the config on the server in order to pull in the latest changes.

*Motivation:*
- This will allow us to have a separate config that has the api credentials and base urls.
- This file will live in the conf directory in the app project and is not required.
- As credentials, keys, or base urls stays the same, we do not have to checkout the config every time to change these details.

Could we include this change into the provider?