### PR TITLE
adding release to node environment variable

### DIFF
--- a/start.js
+++ b/start.js
@@ -22,7 +22,10 @@ require('./lib/atajo.env').init(function() {
                 URI = SERVER.protocol + '://' + SERVER.host + ':' + SERVER.port;
 
                 atajo.log.d("CONNECTING TO : " + URI + " (" + RELEASE + ")");
-
+                
+                //set node environment variable to call from other provider scripts.
+                process.env.NODE_ENV = RELEASE;
+                
                 atajo.io.init(RELEASE, URI);
 
 


### PR DESCRIPTION
Hi could you please add a NODE_ENV variable to the start.js file of the provider ?
Then we can get the environment the provider is running on from the NODE_ENV variable in handlers and other scripts in the provider by calling process.env.NODE_ENV.